### PR TITLE
Filter models by OpenAI provider

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -1571,7 +1571,7 @@ async function deleteAssistant(assistant_id) {
 }
 
 function loadModels() {
-    fetch(new URL('/chat/api/getModels?filter=gpt*', httpBase))
+    fetch(new URL('/chat/api/getModels?provider=openai', httpBase))
         .then(resp => resp.ok ? resp.json() : Promise.reject(resp.statusText))
         .then(items => {
             models = items.length > 0 ? items : models;


### PR DESCRIPTION
The OPAL backend needs to be upgraded in order to use that provider models filter